### PR TITLE
fix undefined storage issue

### DIFF
--- a/utils/localStorage.ts
+++ b/utils/localStorage.ts
@@ -1,4 +1,9 @@
 export const save = (key: string, value: any): void => {
+  if (!value) {
+    console.warn(`Tried to save value ${value} to localStorage with key ${key}. Skipping...`);
+    return;
+  }
+
   window?.localStorage.setItem(key, JSON.stringify(value));
 };
 

--- a/utils/localStorage.ts
+++ b/utils/localStorage.ts
@@ -1,5 +1,5 @@
 export const save = (key: string, value: any): void => {
-  if (!value) {
+  if (!key || !value) {
     console.warn(`Tried to save value ${value} to localStorage with key ${key}. Skipping...`);
     return;
   }


### PR DESCRIPTION
This should (hopefully) fix an issue where an undefined value is being saved to local storage which overwrites the course content with a blank page. The intention of storing these is to make load times much faster by manually caching the course section titles / descriptions but this occasional issue causes this to break in a way that cannot be recovered without clearing localStorage.

![image](https://github.com/user-attachments/assets/3879d91a-ec9c-4465-90ef-ffe93adef064)
